### PR TITLE
Update README formatting, include license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Mike Crabb, and 2019 Clint Bellanger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-ORCID.js
-========
+# ORCID.js
 
-##Client Side ORCID Generator
+## Client Side ORCID Generator
 
 This library creates a simple way to include ORCID Works information on pages that allow Javascripts to be added.
 
@@ -9,20 +8,21 @@ Based on the ORCID.js library by Mike Crabb. https://github.com/mikecrabb/ORCID.
 
 For citations using BibTex format, requires bibtexParseJs by ORCID: https://github.com/ORCID/bibtexParseJs -- MIT License
 
-##Details
+## Details
 
 This library looks up a list of Works associated with an ORCID ID. For each work it displays the citation information (supporting plaintext or BibTex) and the URL. Optionally it also displays a formatted link to that ORCID profile.
 
-##Hello World Example
+## Hello World Example
 
 Example of using this script in a simple HTML page:
 
 https://github.com/AuburnUniversityLibraries/ORCID.js/blob/master/index.html
 
-##See Also
+## See Also
 
 ORCID has an official ORCID-js library that is more feature complete and comes with more dependencies: https://github.com/ORCID/orcid-js
 
-##Licence
+## Licence
+
 * This is made available and licensed under the MIT License:
 * https://opensource.org/licenses/mit-license.html


### PR DESCRIPTION
Add MIT license file, minor formatting tweaks

- Sufficient formatting tweaks to allow GitHub
    to render the sections properly

- Add license file
    - explicitly list out all contributors
    - allow GitHub to clearly list license for the repo
